### PR TITLE
Add DEFAULT_EXCHANGE and AVAILABILITY_ERRORS constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ require 'rabbitmq'
 
 publisher = RabbitMQ::Client.new.start.channel
 queue     = "some_queue"
-exchange  = "" # default exchange
+exchange  = RabbitMQ::DEFAULT_EXCHANGE
 publisher.queue_delete(queue)
 publisher.queue_declare(queue)
 

--- a/example/memory/publisher.rb
+++ b/example/memory/publisher.rb
@@ -9,7 +9,7 @@ sleep_time  = 0.1 # time in seconds to sleep in between each batch
 
 publisher = RabbitMQ::Client.new.start.channel
 queue     = "memory_queue"
-exchange  = "" # default exchange
+exchange  = RabbitMQ::DEFAULT_EXCHANGE
 publisher.queue_declare(queue)
 
 while true

--- a/example/publish_500.rb
+++ b/example/publish_500.rb
@@ -3,7 +3,7 @@ require 'rabbitmq'
 
 publisher = RabbitMQ::Client.new.start.channel
 queue     = "some_queue"
-exchange  = "" # default exchange
+exchange  = RabbitMQ::DEFAULT_EXCHANGE
 publisher.queue_delete(queue)
 publisher.queue_declare(queue)
 

--- a/lib/rabbitmq.rb
+++ b/lib/rabbitmq.rb
@@ -9,3 +9,18 @@ require_relative 'rabbitmq/server_error'
 
 require_relative 'rabbitmq/client'
 require_relative 'rabbitmq/channel'
+
+
+module RabbitMQ
+  # The RabbitMQ default exchange.
+  DEFAULT_EXCHANGE = "".freeze
+  
+  # An array of errors that indicate an availabilty issue.
+  AVAILABILITY_ERRORS = [
+    RabbitMQ::ServerError::ConnectionError,
+    RabbitMQ::FFI::Error::Timeout,
+    RabbitMQ::FFI::Error::ConnectionClosed,
+    RabbitMQ::FFI::Error::SocketError,
+    RabbitMQ::FFI::Error::BadAmqpData,
+  ].freeze
+end

--- a/spec/channel_spec.rb
+++ b/spec/channel_spec.rb
@@ -192,15 +192,15 @@ describe RabbitMQ::Channel do
     subject.queue_delete("my_queue")
     subject.queue_declare("my_queue")
     
-    res = subject.basic_publish("message_body", "", "my_queue",
-                                persistent: true, priority: 5)
+    res = subject.basic_publish("message_body", RabbitMQ::DEFAULT_EXCHANGE,
+                                "my_queue", persistent: true, priority: 5)
     res.should eq true
     
     res = subject.basic_get("my_queue", no_ack: true)
     res[:method].should eq :basic_get_ok
     res[:properties].delete(:delivery_tag) .should be_an Integer
     res[:properties].delete(:redelivered)  .should eq false
-    res[:properties].delete(:exchange)     .should eq ""
+    res[:properties].delete(:exchange)     .should eq RabbitMQ::DEFAULT_EXCHANGE
     res[:properties].delete(:routing_key)  .should eq "my_queue"
     res[:properties].delete(:message_count).should eq 0
     res[:properties].should be_empty
@@ -222,7 +222,7 @@ describe RabbitMQ::Channel do
     
     # Publish some messages to the queue
     10.times do |i|
-      subject.basic_publish("message_#{i}", "", "my_queue")
+      subject.basic_publish("message_#{i}", RabbitMQ::DEFAULT_EXCHANGE, "my_queue")
     end
     
     # Negotiate this channel as a consumer of the queue
@@ -240,7 +240,7 @@ describe RabbitMQ::Channel do
       
       res[:method].should eq :basic_deliver
       res[:properties].delete(:redelivered).should eq false
-      res[:properties].delete(:exchange)   .should eq ""
+      res[:properties].delete(:exchange)   .should eq RabbitMQ::DEFAULT_EXCHANGE
       res[:properties].delete(:routing_key).should eq "my_queue"
       res[:properties].should be_empty
       res[:header].should be_a Hash

--- a/spec/rabbitmq_spec.rb
+++ b/spec/rabbitmq_spec.rb
@@ -1,0 +1,22 @@
+
+require 'spec_helper'
+
+
+describe RabbitMQ do
+  describe "DEFAULT_EXCHANGE" do
+    subject { RabbitMQ::DEFAULT_EXCHANGE }
+    
+    it { should eq "" }
+  end
+  
+  describe "AVAILABILITY_ERRORS" do
+    subject { RabbitMQ::AVAILABILITY_ERRORS }
+    
+    it { should be_an Array }
+    it { should_not be_empty }
+    
+    specify "each element is a subclass of Exception" do
+      subject.all? { |e| e < Exception }.should be true
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `DEFAULT_EXCHANGE` and `AVAILABILITY_ERRORS` constants we discussed.

Just FYI, this test was failing on `master` before I started the work, and is still failing:

```
RabbitMQ::Channel .........................
RabbitMQ::Client::Connection .............
RabbitMQ::Client F..........................................

  1) RabbitMQ::Client closes itself from server-sent connection error closure
     Failure/Error:
       expect {
         subject.send_request(11, :channel_open)
         subject.fetch_response(11, :channel_open_ok)
       }.to raise_error RabbitMQ::ServerError::ConnectionError::CommandInvalid

       expected RabbitMQ::ServerError::ConnectionError::CommandInvalid, got #<RabbitMQ::ServerError::ConnectionError::ChannelError: CHANNEL_ERROR - second 'channel.open' seen> with backtrace:
         # ./lib/rabbitmq/client.rb:297:in `raise_if_server_error!'
         # ./lib/rabbitmq/client.rb:282:in `store_incoming_event'
         # ./lib/rabbitmq/client.rb:322:in `fetch_response_internal'
         # ./lib/rabbitmq/client.rb:128:in `fetch_response'
         # ./spec/client_spec.rb:107:in `block (3 levels) in <top (required)>'
         # ./spec/client_spec.rb:105:in `block (2 levels) in <top (required)>'
     # ./spec/client_spec.rb:105:in `block (2 levels) in <top (required)>'
RabbitMQ::FFI .....
RabbitMQ ..
RabbitMQ::Util ..........

Finished in 1.73 seconds (files took 0.24652 seconds to load)
98 examples, 1 failure
```
