### PR TITLE
Add rabbitmq.dylib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ ext/rabbitmq/rabbitmq-c.tar.gz
 ext/rabbitmq/rabbitmq-c
 ext/rabbitmq/config.status
 ext/rabbitmq/librabbitmq.so
+ext/rabbitmq/librabbitmq.dylib
 lib/rabbitmq/ffi/gen
 lib/rabbitmq/ffi/gen.rb


### PR DESCRIPTION
This was created for me when I ran `rake vendor`. I don't know if it's a convention to put this into the global `.gitignore`, but I thought it would be good to put this specific file in local `.gitignore` as well.