### PR TITLE
Handle URLs with trailing slash correctly

### DIFF
--- a/lib/rabbitmq/util.rb
+++ b/lib/rabbitmq/util.rb
@@ -39,6 +39,7 @@ module RabbitMQ
       result = info.to_h
       
       if url
+        url = url.chomp("/") # RabbitMQ library doesn't handle trailing slashes correctly
         url_ptr = Util.strdup_ptr(url)
         Util.error_check :"parsing connection URL",
           FFI.amqp_parse_url(url_ptr, info)

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -108,5 +108,18 @@ describe RabbitMQ::Util do
         ssl:      true
       )
     end
+
+    it "given a URL with trailing slash parses URL correctly" do
+      subject.connection_info(
+        "amqp://user:password@host:1234/",
+      ).should eq(
+        user:     "user",
+        password: "password",
+        host:     "host",
+        vhost:    "/",
+        port:     1234,
+        ssl:      false
+      )
+    end
   end
 end


### PR DESCRIPTION
When I tried to connect to an AMQP URL which had a trailing slash (and no path), I got a `NotImplementedError` in `RabbitMQ::Connection#login!`. After a little digging I found out that the URLs with trailing slashes aren't correctly parsed; the `vhost` was extracted as `""` instead of `"/"`. When I removed the trailing slash, the connection was established just fine.

I don't know if this is supposed to be fixed in the RabbitMQ project or here, but the fix was easy.